### PR TITLE
WIP: Add WIN32 environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tags
 /mruby-source-*.gem
 doc/api
 .yardoc
+/.vscode


### PR DESCRIPTION
This is sample implementation to build Win32 environment.
It can build at VS2017.

This code includes these changes.
* Add target variable for WIN32 build.
* Use Winsock2 for WIN32 build target, and add #pragma to link winsock library.
* Use default instead of MSG_NOSIGNAL.(It is not defined.)
* Change some error handlings to support multi-platform environment.
* Some debug codes are removed, or available when DEBUG flag enabled.

This code has some problems.
* In build VS2017, receive result failed and timeout after irep send. (I don't know why, if you have good idea, please note me.)
* It seems to process fail on target device when proc object received. (ex: `100.times{ somemethod.call() }`), Is it a mruby/c problem?

Todo:
* Fix some bugs.
* Write document to build VS2017.